### PR TITLE
Replace schemes with globals

### DIFF
--- a/inc/widgets-manager/widgets/content/class-banas-slider.php
+++ b/inc/widgets-manager/widgets/content/class-banas-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-beas-slider.php
+++ b/inc/widgets-manager/widgets/content/class-beas-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-ce-cycle-heading.php
+++ b/inc/widgets-manager/widgets/content/class-ce-cycle-heading.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-ce-featured-podcast.php
+++ b/inc/widgets-manager/widgets/content/class-ce-featured-podcast.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -257,7 +254,9 @@ class Featured_Podcast extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .entry-featured-podcast h5',
 			]
 		);
@@ -279,7 +278,9 @@ class Featured_Podcast extends Widget_Base {
 			[
 				'name' => 'item_meta_typography',
 				'label' => __( 'Item Meta Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-meta-single',
 			]
 		);
@@ -301,7 +302,9 @@ class Featured_Podcast extends Widget_Base {
 			[
 				'name' => 'item_content_typography',
 				'label' => __( 'Item Content Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-content',
 			]
 		);
@@ -323,7 +326,9 @@ class Featured_Podcast extends Widget_Base {
 			[
 				'name' => 'item_readmore_typography',
 				'label' => __( '"Continue Reading" Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-readmore',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-podcasts-carousel.php
+++ b/inc/widgets-manager/widgets/content/class-ce-podcasts-carousel.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -436,7 +433,9 @@ class Podcasts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-title',
 			]
 		);
@@ -458,7 +457,9 @@ class Podcasts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_meta_typography',
 				'label' => __( 'Item Meta Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-meta-single',
 			]
 		);
@@ -480,7 +481,9 @@ class Podcasts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_content_typography',
 				'label' => __( 'Item Content Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-content',
 			]
 		);
@@ -502,7 +505,9 @@ class Podcasts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_readmore_typography',
 				'label' => __( '"Continue Reading" Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-readmore',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-podcasts-grid.php
+++ b/inc/widgets-manager/widgets/content/class-ce-podcasts-grid.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -289,7 +286,9 @@ class Podcasts_Grid extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-title',
 			]
 		);
@@ -311,7 +310,9 @@ class Podcasts_Grid extends Widget_Base {
 			[
 				'name' => 'item_meta_typography',
 				'label' => __( 'Item Meta Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-meta-single',
 			]
 		);
@@ -333,7 +334,9 @@ class Podcasts_Grid extends Widget_Base {
 			[
 				'name' => 'item_content_typography',
 				'label' => __( 'Item Content Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-content',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-portfolio-carousel.php
+++ b/inc/widgets-manager/widgets/content/class-ce-portfolio-carousel.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -356,7 +353,9 @@ class Portfolio_Carousel extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-title',
 			]
 		);
@@ -378,7 +377,9 @@ class Portfolio_Carousel extends Widget_Base {
 			[
 				'name' => 'item_cats_typography',
 				'label' => __( 'Item Categories Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-categories',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-portfolio-grid.php
+++ b/inc/widgets-manager/widgets/content/class-ce-portfolio-grid.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -356,7 +353,9 @@ class Portfolio_Grid extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-title, body.ce-portfolio-follow-erzen .ce-fixed-follow .portfolio-title',
 			]
 		);
@@ -366,7 +365,9 @@ class Portfolio_Grid extends Widget_Base {
 			[
 				'name' => 'filter_links_typography',
 				'label' => __( 'Filter Links Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-filters button',
 				'condition' => [
                     'module' => 'predefined'
@@ -391,7 +392,9 @@ class Portfolio_Grid extends Widget_Base {
 			[
 				'name' => 'item_cats_typography',
 				'label' => __( 'Item Categories Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-categories, body.ce-portfolio-follow-erzen .ce-fixed-follow .portfolio-categories',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-post-navigation.php
+++ b/inc/widgets-manager/widgets/content/class-ce-post-navigation.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-ce-posts-carousel.php
+++ b/inc/widgets-manager/widgets/content/class-ce-posts-carousel.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -437,7 +434,9 @@ class Posts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-title',
 			]
 		);
@@ -459,7 +458,9 @@ class Posts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_meta_typography',
 				'label' => __( 'Item Meta Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-meta-single',
 			]
 		);
@@ -481,7 +482,9 @@ class Posts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_content_typography',
 				'label' => __( 'Item Content Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-content',
 			]
 		);
@@ -503,7 +506,9 @@ class Posts_Carousel extends Widget_Base {
 			[
 				'name' => 'item_readmore_typography',
 				'label' => __( '"Continue Reading" Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-readmore',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-posts-grid.php
+++ b/inc/widgets-manager/widgets/content/class-ce-posts-grid.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -290,7 +287,9 @@ class Posts_Grid extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-title',
 			]
 		);
@@ -312,7 +311,9 @@ class Posts_Grid extends Widget_Base {
 			[
 				'name' => 'item_meta_typography',
 				'label' => __( 'Item Meta Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-meta-single',
 			]
 		);
@@ -334,7 +335,9 @@ class Posts_Grid extends Widget_Base {
 			[
 				'name' => 'item_content_typography',
 				'label' => __( 'Item Content Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-content',
 			]
 		);
@@ -356,7 +359,9 @@ class Posts_Grid extends Widget_Base {
 			[
 				'name' => 'item_readmore_typography',
 				'label' => __( '"Continue Reading" Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-readmore',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-products-carousel.php
+++ b/inc/widgets-manager/widgets/content/class-ce-products-carousel.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -355,7 +352,9 @@ class Products_Carousel extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-title',
 			]
 		);
@@ -377,7 +376,9 @@ class Products_Carousel extends Widget_Base {
 			[
 				'name' => 'item_cats_typography',
 				'label' => __( 'Item Categories Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-categories',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-products-grid.php
+++ b/inc/widgets-manager/widgets/content/class-ce-products-grid.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -338,7 +335,9 @@ class Products_Grid extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-title, body.ce-portfolio-follow-erzen .ce-fixed-follow .portfolio-title',
 			]
 		);
@@ -348,7 +347,9 @@ class Products_Grid extends Widget_Base {
 			[
 				'name' => 'filter_links_typography',
 				'label' => __( 'Filter Links Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-filters button',
 				'condition' => [
                     'module' => 'predefined'
@@ -373,7 +374,9 @@ class Products_Grid extends Widget_Base {
 			[
 				'name' => 'item_cats_typography',
 				'label' => __( 'Item Categories Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-portfolio-item .portfolio-categories, body.ce-portfolio-follow-erzen .ce-fixed-follow .portfolio-categories',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-shows.php
+++ b/inc/widgets-manager/widgets/content/class-ce-shows.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -436,7 +433,9 @@ class Podcasts_Shows_Carousel extends Widget_Base {
 			[
 				'name' => 'item_title_typography',
 				'label' => __( 'Item Title Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-titles',
 			]
 		);
@@ -458,7 +457,9 @@ class Podcasts_Shows_Carousel extends Widget_Base {
 			[
 				'name' => 'item_meta_typography',
 				'label' => __( 'Item Meta Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-meta-single',
 			]
 		);
@@ -480,7 +481,9 @@ class Podcasts_Shows_Carousel extends Widget_Base {
 			[
 				'name' => 'item_content_typography',
 				'label' => __( 'Item Content Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-content',
 			]
 		);
@@ -502,7 +505,9 @@ class Podcasts_Shows_Carousel extends Widget_Base {
 			[
 				'name' => 'item_readmore_typography',
 				'label' => __( '"Continue Reading" Typography', 'cowidgets' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-post-item .entry-readmore',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-staff-carousel.php
+++ b/inc/widgets-manager/widgets/content/class-ce-staff-carousel.php
@@ -8,12 +8,9 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -364,7 +361,9 @@ class Staff_Carousel extends Widget_Base {
 			[
 				'name' => 'staff_name_typography',
 				'label' => __( 'Staff Name Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-staff-item .team-name',
 			]
 		);
@@ -387,7 +386,9 @@ class Staff_Carousel extends Widget_Base {
 			[
 				'name' => 'staff_position_typography',
 				'label' => __( 'Staff Work Position Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-staff-item .team-position',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-testimonial-carousel.php
+++ b/inc/widgets-manager/widgets/content/class-ce-testimonial-carousel.php
@@ -8,12 +8,8 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
-use Elementor\Group_Control_Image_Size;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -359,7 +355,9 @@ class Testimonial_Carousel extends Widget_Base {
 			[
 				'name' => 'text_typography',
 				'label' => __( 'Item Text Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-testimonial-item .text',
 			]
 		);
@@ -381,7 +379,9 @@ class Testimonial_Carousel extends Widget_Base {
 			[
 				'name' => 'testimon_typography',
 				'label' => __( 'Item Testimon Name Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-testimonial-item .data .title',
 			]
 		);
@@ -403,7 +403,9 @@ class Testimonial_Carousel extends Widget_Base {
 			[
 				'name' => 'testimon_position_typography',
 				'label' => __( 'Item Work Position Typography', 'plugin-domain' ),
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-testimonial-item .data .position',
 			]
 		);

--- a/inc/widgets-manager/widgets/content/class-ce-video-play-button.php
+++ b/inc/widgets-manager/widgets/content/class-ce-video-play-button.php
@@ -8,12 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
-use Elementor\Group_Control_Image_Size;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.

--- a/inc/widgets-manager/widgets/content/class-hudson-slider.php
+++ b/inc/widgets-manager/widgets/content/class-hudson-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-kiri-slider.php
+++ b/inc/widgets-manager/widgets/content/class-kiri-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-lana-slider.php
+++ b/inc/widgets-manager/widgets/content/class-lana-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-mailchimp-form.php
+++ b/inc/widgets-manager/widgets/content/class-mailchimp-form.php
@@ -8,10 +8,6 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
-use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-pao-slider.php
+++ b/inc/widgets-manager/widgets/content/class-pao-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-tapi-slider.php
+++ b/inc/widgets-manager/widgets/content/class-tapi-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/content/class-vjosa-slider.php
+++ b/inc/widgets-manager/widgets/content/class-vjosa-slider.php
@@ -8,10 +8,7 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/inc/widgets-manager/widgets/header/class-cart.php
+++ b/inc/widgets-manager/widgets/header/class-cart.php
@@ -9,12 +9,8 @@ namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Widget_Base;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Core\Schemes\Color;
-use Elementor\Core\Schemes;
-use Elementor\Group_Control_Border;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -239,7 +235,9 @@ class Cart extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'      => 'toggle_button_typography',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .ce-menu-cart__toggle .elementor-button',
 				'condition' => [
 					'ce_cart_type' => 'custom',

--- a/inc/widgets-manager/widgets/header/class-copyright.php
+++ b/inc/widgets-manager/widgets/header/class-copyright.php
@@ -8,11 +8,10 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -154,9 +153,8 @@ class Copyright extends Widget_Base {
 			[
 				'label'     => __( 'Text Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
 					// Stronger selector to avoid section style from overwriting.
@@ -170,7 +168,9 @@ class Copyright extends Widget_Base {
 			[
 				'name'     => 'caption_typography',
 				'selector' => '{{WRAPPER}} .ce-copyright-wrapper, {{WRAPPER}} .ce-copyright-wrapper a',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			]
 		);
 	}

--- a/inc/widgets-manager/widgets/header/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/header/class-navigation-menu.php
@@ -9,15 +9,13 @@ namespace COWIDGETS\WidgetsManager\Widgets;
 
 // Elementor Classes.
 use Elementor\Controls_Manager;
-use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Background;
 use Elementor\Widget_Base;
-use Elementor\Plugin;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -933,7 +931,9 @@ class Navigation_Menu extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'      => 'menu_typography',
-				'scheme'    => Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'separator' => 'before',
 				'selector'  => '{{WRAPPER}} a.ce-menu-item, {{WRAPPER}} a.ce-sub-menu-item',
 			]
@@ -953,9 +953,8 @@ class Navigation_Menu extends Widget_Base {
 						[
 							'label'     => __( 'Text Color', 'cowidgets' ),
 							'type'      => Controls_Manager::COLOR,
-							'scheme'    => [
-								'type'  => Color::get_type(),
-								'value' => Color::COLOR_3,
+							'global'    => [
+								'default' => Global_Colors::COLOR_TEXT,
 							],
 							'default'   => '',
 							'selectors' => [
@@ -993,9 +992,8 @@ class Navigation_Menu extends Widget_Base {
 						[
 							'label'     => __( 'Text Color', 'cowidgets' ),
 							'type'      => Controls_Manager::COLOR,
-							'scheme'    => [
-								'type'  => Color::get_type(),
-								'value' => Color::COLOR_4,
+							'global'    => [
+								'default' => Global_Colors::COLOR_ACCENT,
 							],
 							'selectors' => [
 								'{{WRAPPER}} .menu-item a.ce-menu-item:hover,
@@ -1030,9 +1028,8 @@ class Navigation_Menu extends Widget_Base {
 						[
 							'label'     => __( 'Link Hover Effect Color', 'cowidgets' ),
 							'type'      => Controls_Manager::COLOR,
-							'scheme'    => [
-								'type'  => Color::get_type(),
-								'value' => Color::COLOR_4,
+							'global'    => [
+								'default' => Global_Colors::COLOR_ACCENT,
 							],
 							'default'   => '',
 							'selectors' => [
@@ -1234,7 +1231,9 @@ class Navigation_Menu extends Widget_Base {
 				Group_Control_Typography::get_type(),
 				[
 					'name'      => 'dropdown_typography',
-					'scheme'    => Typography::TYPOGRAPHY_4,
+					'global'    => [
+						'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+					],
 					'separator' => 'before',
 					'selector'  => '
 							{{WRAPPER}} .sub-menu li a.ce-sub-menu-item,
@@ -1636,7 +1635,9 @@ class Navigation_Menu extends Widget_Base {
 				[
 					'name'     => 'all_typography',
 					'label'    => __( 'Typography', 'cowidgets' ),
-					'scheme'   => Typography::TYPOGRAPHY_4,
+					'global'   => [
+						'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+					],
 					'selector' => '{{WRAPPER}} .menu-item a.ce-menu-item.elementor-button',
 				]
 			);
@@ -1682,9 +1683,8 @@ class Navigation_Menu extends Widget_Base {
 							'selector'       => '{{WRAPPER}} .menu-item a.ce-menu-item.elementor-button',
 							'fields_options' => [
 								'color' => [
-									'scheme' => [
-										'type'  => Color::get_type(),
-										'value' => Color::COLOR_4,
+									'global'    => [
+										'default' => Global_Colors::COLOR_ACCENT,
 									],
 								],
 							],
@@ -1749,9 +1749,8 @@ class Navigation_Menu extends Widget_Base {
 							'selector'       => '{{WRAPPER}} .menu-item a.ce-menu-item.elementor-button:hover',
 							'fields_options' => [
 								'color' => [
-									'scheme' => [
-										'type'  => Color::get_type(),
-										'value' => Color::COLOR_4,
+									'global' => [
+										'default' => Global_Colors::COLOR_ACCENT,
 									],
 								],
 							],

--- a/inc/widgets-manager/widgets/header/class-page-title.php
+++ b/inc/widgets-manager/widgets/header/class-page-title.php
@@ -11,8 +11,8 @@ use Elementor\Controls_Manager;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -276,7 +276,9 @@ class Page_Title extends Widget_Base {
 				Group_Control_Typography::get_type(),
 				[
 					'name'     => 'title_typography',
-					'scheme'   => Typography::TYPOGRAPHY_1,
+					'global'   => [
+						'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+					],
 					'selector' => '{{WRAPPER}} .elementor-heading-title, {{WRAPPER}} .ce-page-title a',
 				]
 			);
@@ -286,11 +288,10 @@ class Page_Title extends Widget_Base {
 				[
 					'label'     => __( 'Color', 'cowidgets' ),
 					'type'      => Controls_Manager::COLOR,
-					'scheme'    => [
-						'type'  => Color::get_type(),
-						'value' => Color::COLOR_1,
+					'global'    => [
+						'default' => Global_Colors::COLOR_PRIMARY,
 					],
-					'selectors' => [
+						'selectors' => [
 						'{{WRAPPER}} .elementor-heading-title, {{WRAPPER}} .ce-page-title a' => 'color: {{VALUE}};',
 						'{{WRAPPER}} .ce-page-title-icon i'   => 'color: {{VALUE}};',
 						'{{WRAPPER}} .ce-page-title-icon svg' => 'fill: {{VALUE}};',
@@ -350,9 +351,8 @@ class Page_Title extends Widget_Base {
 			[
 				'label'     => __( 'Icon Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'new_page_title_select_icon[value]!' => '',

--- a/inc/widgets-manager/widgets/header/class-retina.php
+++ b/inc/widgets-manager/widgets/header/class-retina.php
@@ -8,18 +8,16 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Control_Media;
 use Elementor\Utils;
-use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Css_Filter;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Plugin;
 use Elementor\Widget_Base;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -369,9 +367,8 @@ class Retina extends Widget_Base {
 			[
 				'label'     => __( 'Border Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'retina_image_border!' => 'none',
@@ -532,9 +529,8 @@ class Retina extends Widget_Base {
 				'selectors' => [
 					'{{WRAPPER}} .widget-image-caption' => 'color: {{VALUE}};',
 				],
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 			]
 		);
@@ -555,7 +551,9 @@ class Retina extends Widget_Base {
 			[
 				'name'     => 'caption_typography',
 				'selector' => '{{WRAPPER}} .widget-image-caption',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			]
 		);
 

--- a/inc/widgets-manager/widgets/header/class-site-logo.php
+++ b/inc/widgets-manager/widgets/header/class-site-logo.php
@@ -8,19 +8,16 @@
 namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Control_Media;
 use Elementor\Utils;
-use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
 use Elementor\Group_Control_Image_Size;
-use Elementor\Repeater;
 use Elementor\Group_Control_Css_Filter;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Plugin;
 use Elementor\Widget_Base;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -411,9 +408,8 @@ class Site_Logo extends Widget_Base {
 			[
 				'label'     => __( 'Border Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'site_logo_image_border!' => 'none',
@@ -574,9 +570,8 @@ class Site_Logo extends Widget_Base {
 				'selectors' => [
 					'{{WRAPPER}} .widget-image-caption' => 'color: {{VALUE}};',
 				],
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 			]
 		);
@@ -597,7 +592,9 @@ class Site_Logo extends Widget_Base {
 			[
 				'name'     => 'caption_typography',
 				'selector' => '{{WRAPPER}} .widget-image-caption',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			]
 		);
 

--- a/inc/widgets-manager/widgets/header/class-site-tagline.php
+++ b/inc/widgets-manager/widgets/header/class-site-tagline.php
@@ -9,10 +9,9 @@ namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Widget_Base;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -194,7 +193,9 @@ class Site_Tagline extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'     => 'tagline_typography',
-				'scheme'   => Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'selector' => '{{WRAPPER}} .ce-site-tagline',
 			]
 		);
@@ -203,9 +204,8 @@ class Site_Tagline extends Widget_Base {
 			[
 				'label'     => __( 'Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .ce-site-tagline' => 'color: {{VALUE}};',
@@ -220,9 +220,8 @@ class Site_Tagline extends Widget_Base {
 			[
 				'label'     => __( 'Icon Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'icon[value]!' => '',

--- a/inc/widgets-manager/widgets/header/class-site-title.php
+++ b/inc/widgets-manager/widgets/header/class-site-title.php
@@ -9,10 +9,10 @@ namespace COWIDGETS\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Text_Shadow;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -277,7 +277,9 @@ class Site_Title extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'     => 'heading_typography',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .elementor-heading-title, {{WRAPPER}} .ce-heading a',
 			]
 		);
@@ -286,9 +288,8 @@ class Site_Title extends Widget_Base {
 			[
 				'label'     => __( 'Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .ce-heading-text' => 'color: {{VALUE}};',
@@ -349,9 +350,8 @@ class Site_Title extends Widget_Base {
 			[
 				'label'     => __( 'Icon Color', 'cowidgets' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'icon[value]!' => '',


### PR DESCRIPTION
The plugin is using the deprecated "**Schemes**" mechanism that had been replaced with "**Globals**" in Elementor 3.0.0 (in 2020).

Ref: https://developers.elementor.com/docs/deprecations/complex-example/